### PR TITLE
Add and verify "proof" in JSON

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 }
 
 final def spockVersion = '1.1-groovy-2.4'
-final def edVersion = '1.3.2'
+final def edVersion = '1.3.3'
 final def spockGenesisVersion = '0.6.0'
 final def jacksonVersion = '2.9.6'
 final def onecodeVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ final def lombokVersion = '1.18.2'
 final def cglibVersion = '3.2.7'
 final def bytebuddyVersion = '1.8.16'
 final def objgenesisVersion = '2.6'
+final def validationVersion = '2.0.1.Final'
 
 
 dependencies {
@@ -59,6 +60,8 @@ dependencies {
     testCompileOnly("org.projectlombok:lombok:${lombokVersion}")
     testCompile("com.nagternal:spock-genesis:${spockGenesisVersion}")
     testCompile("org.spockframework:spock-core:${spockVersion}")
+
+    compile("javax.validation:validation-api:${validationVersion}")
 
     compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
     compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 }
 
 final def spockVersion = '1.1-groovy-2.4'
-final def edVersion = '1.2.0'
+final def edVersion = '1.3.1'
 final def spockGenesisVersion = '0.6.0'
 final def jacksonVersion = '2.9.6'
 final def onecodeVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 }
 
 final def spockVersion = '1.1-groovy-2.4'
-final def edVersion = '1.3.1'
+final def edVersion = '1.3.2'
 final def spockGenesisVersion = '0.6.0'
 final def jacksonVersion = '2.9.6'
 final def onecodeVersion = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -43,15 +43,21 @@ final def edVersion = '1.2.0'
 final def spockGenesisVersion = '0.6.0'
 final def jacksonVersion = '2.9.6'
 final def onecodeVersion = '1.0.1'
-final def lombokVersion = '1.18.0'
+final def lombokVersion = '1.18.2'
 final def cglibVersion = '3.2.7'
+final def bytebuddyVersion = '1.8.16'
+final def objgenesisVersion = '2.6'
 
 
 dependencies {
+    // for mocking in groovy
+    testCompile("net.bytebuddy:byte-buddy:${bytebuddyVersion}")
+    testCompile("org.objenesis:objenesis:${objgenesisVersion}")
+    testCompile("cglib:cglib-nodep:${cglibVersion}")
+
     compileOnly("org.projectlombok:lombok:${lombokVersion}")
     testCompileOnly("org.projectlombok:lombok:${lombokVersion}")
     testCompile("com.nagternal:spock-genesis:${spockGenesisVersion}")
-    testCompile("cglib:cglib-nodep:${cglibVersion}") // for mocking in spock
     testCompile("org.spockframework:spock-core:${spockVersion}")
 
     compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"

--- a/src/main/java/jp/co/soramitsu/sora/common/SaltGenerator.java
+++ b/src/main/java/jp/co/soramitsu/sora/common/SaltGenerator.java
@@ -4,6 +4,7 @@ public interface SaltGenerator {
 
   /**
    * Get next salt represented as string.
+   *
    * @return salt
    */
   String next();

--- a/src/main/java/jp/co/soramitsu/sora/common/Util.java
+++ b/src/main/java/jp/co/soramitsu/sora/common/Util.java
@@ -1,7 +1,12 @@
 package jp.co.soramitsu.sora.common;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
 import java.security.MessageDigest;
 import jp.co.soramitsu.sora.crypto.Hash;
+import jp.co.soramitsu.sora.crypto.common.Consts;
+import jp.co.soramitsu.sora.crypto.proof.Options;
+import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
 import org.spongycastle.util.Arrays;
 
 public class Util {
@@ -35,5 +40,19 @@ public class Util {
             )
         )
     );
+  }
+
+  static public byte[] serializeWithOptions(
+      JSONCanonizer canonizer, ObjectNode root, Options options)
+      throws IOException {
+    byte[] canonized = canonizer.canonize(root);
+    byte[] opts = canonizer.canonize(options);
+    return Arrays.concatenate(canonized, opts);
+  }
+
+  static public ObjectNode deepCopyWithoutProofNode(ObjectNode root) {
+    ObjectNode out = root.deepCopy();
+    out.remove(Consts.PROOF_KEY);
+    return out;
   }
 }

--- a/src/main/java/jp/co/soramitsu/sora/common/Util.java
+++ b/src/main/java/jp/co/soramitsu/sora/common/Util.java
@@ -3,6 +3,8 @@ package jp.co.soramitsu.sora.common;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.security.MessageDigest;
+import java.security.Signature;
+import java.security.SignatureException;
 import jp.co.soramitsu.sora.crypto.Hash;
 import jp.co.soramitsu.sora.crypto.common.Consts;
 import jp.co.soramitsu.sora.crypto.proof.Options;
@@ -42,7 +44,7 @@ public class Util {
     );
   }
 
-  static public byte[] serializeWithOptions(
+  public static byte[] serializeWithOptions(
       JSONCanonizer canonizer, ObjectNode root, Options options)
       throws IOException {
     byte[] canonized = canonizer.canonize(root);
@@ -50,9 +52,21 @@ public class Util {
     return Arrays.concatenate(canonized, opts);
   }
 
-  static public ObjectNode deepCopyWithoutProofNode(ObjectNode root) {
+  public static ObjectNode deepCopyWithoutProofNode(ObjectNode root) {
     ObjectNode out = root.deepCopy();
     out.remove(Consts.PROOF_KEY);
     return out;
+  }
+
+  public static void verifyAlgorithmType(Options options, Signature signature)
+      throws SignatureException {
+    String type = options.getType().getAlgorithm();
+    if (!type.equals(signature.getAlgorithm())) {
+      throw new SignatureException(
+          String
+              .format("options (%s) and signature (%s) have different signature algorithms", type,
+                  signature.getAlgorithm())
+      );
+    }
   }
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/MerkleTreeFactory.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/MerkleTreeFactory.java
@@ -15,14 +15,14 @@ import lombok.val;
 
 public class MerkleTreeFactory {
 
-  private MessageDigest digest;
+  private final MessageDigest digest;
 
   /**
    * Creates instance of MerkleTree with given digest.
    *
    * @param digest implementation of the digest algorithm
-   * @apiNote after you created the instance, method {@link #createFromLeaves(List)} should be called
-   * to calculate tree hashes
+   * @apiNote after you created the instance, method {@link #createFromLeaves(List)} should be
+   * called to calculate tree hashes
    */
   public MerkleTreeFactory(@NonNull MessageDigest digest) {
     this.digest = digest;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/Consts.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/Consts.java
@@ -3,12 +3,12 @@ package jp.co.soramitsu.sora.crypto.common;
 
 public class Consts {
 
-  private Consts() {
-  }
-
   public static final String PROOF_KEY = "proof";
   public static final String ED25519_SHA3_SIGNATURE = "Ed25519Sha3Signature";
   public static final String ED25519_SHA3_VERIFICATION_KEY = "Ed25519Sha3VerificationKey";
   public static final String SHA3_256 = "SHA3-256";
   public static final String SHA3_512 = "SHA3-512";
+
+  private Consts() {
+  }
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/Consts.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/Consts.java
@@ -8,9 +8,9 @@ import lombok.experimental.UtilityClass;
 @FieldDefaults(makeFinal = true)
 public class Consts {
 
-  public static String PROOF_KEY = "proof";
-  public static String ED25519_SHA3_SIGNATURE = "Ed25519Sha3Signature";
-  public static String ED25519_SHA3_VERIFICATION_KEY = "Ed25519Sha3VerificationKey";
-  public static String SHA3_256 = "SHA3-256";
-  public static String SHA3_512 = "SHA3-512";
+  public String PROOF_KEY = "proof";
+  public String ED25519_SHA3_SIGNATURE = "Ed25519Sha3Signature";
+  public String ED25519_SHA3_VERIFICATION_KEY = "Ed25519Sha3VerificationKey";
+  public String SHA3_256 = "SHA3-256";
+  public String SHA3_512 = "SHA3-512";
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/Consts.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/Consts.java
@@ -1,0 +1,14 @@
+package jp.co.soramitsu.sora.crypto.common;
+
+
+public class Consts {
+
+  private Consts() {
+  }
+
+  public static final String PROOF_KEY = "proof";
+  public static final String ED25519_SHA3_SIGNATURE = "Ed25519Sha3Signature";
+  public static final String ED25519_SHA3_VERIFICATION_KEY = "Ed25519Sha3VerificationKey";
+  public static final String SHA3_256 = "SHA3-256";
+  public static final String SHA3_512 = "SHA3-512";
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/Consts.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/Consts.java
@@ -1,14 +1,16 @@
 package jp.co.soramitsu.sora.crypto.common;
 
 
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+@FieldDefaults(makeFinal = true)
 public class Consts {
 
-  public static final String PROOF_KEY = "proof";
-  public static final String ED25519_SHA3_SIGNATURE = "Ed25519Sha3Signature";
-  public static final String ED25519_SHA3_VERIFICATION_KEY = "Ed25519Sha3VerificationKey";
-  public static final String SHA3_256 = "SHA3-256";
-  public static final String SHA3_512 = "SHA3-512";
-
-  private Consts() {
-  }
+  public static String PROOF_KEY = "proof";
+  public static String ED25519_SHA3_SIGNATURE = "Ed25519Sha3Signature";
+  public static String ED25519_SHA3_VERIFICATION_KEY = "Ed25519Sha3VerificationKey";
+  public static String SHA3_256 = "SHA3-256";
+  public static String SHA3_512 = "SHA3-512";
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/DigestTypeEnum.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/DigestTypeEnum.java
@@ -1,0 +1,17 @@
+package jp.co.soramitsu.sora.crypto.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public enum DigestTypeEnum {
+  SHA3_256(Consts.SHA3_256, "SHA3-256", "BC"),
+  SHA3_512(Consts.SHA3_512, "SHA3-512", "BC");
+
+  @Getter
+  private final String type;
+  @Getter
+  private final String algorithm;
+  @Getter
+  private final String provider;
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/DigestTypeEnum.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/DigestTypeEnum.java
@@ -1,15 +1,18 @@
 package jp.co.soramitsu.sora.crypto.common;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.experimental.FieldDefaults;
 
 @AllArgsConstructor
 @Getter
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public enum DigestTypeEnum {
   SHA3_256(Consts.SHA3_256, "SHA3-256", "BC"),
   SHA3_512(Consts.SHA3_512, "SHA3-512", "BC");
 
-  private final String type;
-  private final String algorithm;
-  private final String provider;
+  String type;
+  String algorithm;
+  String provider;
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/DigestTypeEnum.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/DigestTypeEnum.java
@@ -4,14 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @AllArgsConstructor
+@Getter
 public enum DigestTypeEnum {
   SHA3_256(Consts.SHA3_256, "SHA3-256", "BC"),
   SHA3_512(Consts.SHA3_512, "SHA3-512", "BC");
 
-  @Getter
   private final String type;
-  @Getter
   private final String algorithm;
-  @Getter
   private final String provider;
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/KeyTypeEnum.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/KeyTypeEnum.java
@@ -1,0 +1,21 @@
+package jp.co.soramitsu.sora.crypto.common;
+
+import jp.co.soramitsu.crypto.ed25519.EdDSAKey;
+import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum KeyTypeEnum {
+  Ed25519Sha3(
+      Consts.ED25519_SHA3_VERIFICATION_KEY,
+      EdDSAKey.KEY_ALGORITHM,
+      EdDSASecurityProvider.PROVIDER_NAME
+  );
+
+  private String keyType;
+  private String algorithm;
+  private String provider;
+
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/KeyTypeEnum.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/KeyTypeEnum.java
@@ -2,11 +2,14 @@ package jp.co.soramitsu.sora.crypto.common;
 
 import jp.co.soramitsu.crypto.ed25519.EdDSAKey;
 import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.experimental.FieldDefaults;
 
 @AllArgsConstructor
 @Getter
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public enum KeyTypeEnum {
   Ed25519Sha3(
       Consts.ED25519_SHA3_VERIFICATION_KEY,
@@ -14,8 +17,8 @@ public enum KeyTypeEnum {
       EdDSASecurityProvider.PROVIDER_NAME
   );
 
-  private String keyType;
-  private String algorithm;
-  private String provider;
+  String keyType;
+  String algorithm;
+  String provider;
 
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/SecurityProvider.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/SecurityProvider.java
@@ -31,7 +31,7 @@ public class SecurityProvider {
     return MessageDigest.getInstance(type.getAlgorithm(), type.getProvider());
   }
 
-  public KeyPairGenerator getKeyPairGenerator(SignatureTypeEnum type)
+  public KeyPairGenerator getKeyPairGenerator(KeyTypeEnum type)
       throws NoSuchProviderException, NoSuchAlgorithmException {
     return KeyPairGenerator.getInstance(type.getAlgorithm(), type.getProvider());
   }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/SecurityProvider.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/SecurityProvider.java
@@ -1,0 +1,32 @@
+package jp.co.soramitsu.sora.crypto.common;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Security;
+import java.security.Signature;
+import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider;
+import org.spongycastle.jce.provider.BouncyCastleProvider;
+
+
+/**
+ * The purpose of this class is to be a wrapper over static `getInstance` methods, so these static
+ * methods can be mocked.
+ */
+public class SecurityProvider {
+
+  static {
+    Security.addProvider(new EdDSASecurityProvider()); // for ed25519-sha3 crypto
+    Security.addProvider(new BouncyCastleProvider());  // for sha3 hash
+  }
+
+  public Signature getSignature(SignatureTypeEnum type)
+      throws NoSuchAlgorithmException, NoSuchProviderException {
+    return Signature.getInstance(type.getAlgorithm(), type.getProvider());
+  }
+
+  public MessageDigest getMessageDigest(DigestTypeEnum type)
+      throws NoSuchProviderException, NoSuchAlgorithmException {
+    return MessageDigest.getInstance(type.getAlgorithm(), type.getProvider());
+  }
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/SecurityProvider.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/SecurityProvider.java
@@ -1,8 +1,10 @@
 package jp.co.soramitsu.sora.crypto.common;
 
+import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.security.Provider;
 import java.security.Security;
 import java.security.Signature;
 import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider;
@@ -15,9 +17,15 @@ import org.spongycastle.jce.provider.BouncyCastleProvider;
  */
 public class SecurityProvider {
 
+  private static void addProviderOnce(Provider provider) {
+    if (Security.getProvider(provider.getName()) == null) {
+      Security.addProvider(provider);
+    }
+  }
+
   static {
-    Security.addProvider(new EdDSASecurityProvider()); // for ed25519-sha3 crypto
-    Security.addProvider(new BouncyCastleProvider());  // for sha3 hash
+    addProviderOnce(new EdDSASecurityProvider()); // for ed25519-sha3 crypto
+    addProviderOnce(new BouncyCastleProvider());  // for sha3 hash
   }
 
   public Signature getSignature(SignatureTypeEnum type)
@@ -28,5 +36,10 @@ public class SecurityProvider {
   public MessageDigest getMessageDigest(DigestTypeEnum type)
       throws NoSuchProviderException, NoSuchAlgorithmException {
     return MessageDigest.getInstance(type.getAlgorithm(), type.getProvider());
+  }
+
+  public KeyPairGenerator getKeyPairGenerator(SignatureTypeEnum type)
+      throws NoSuchProviderException, NoSuchAlgorithmException {
+    return KeyPairGenerator.getInstance(type.getAlgorithm(), type.getProvider());
   }
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/SecurityProvider.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/SecurityProvider.java
@@ -4,7 +4,6 @@ import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.security.Provider;
 import java.security.Security;
 import java.security.Signature;
 import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider;
@@ -17,15 +16,9 @@ import org.spongycastle.jce.provider.BouncyCastleProvider;
  */
 public class SecurityProvider {
 
-  private static void addProviderOnce(Provider provider) {
-    if (Security.getProvider(provider.getName()) == null) {
-      Security.addProvider(provider);
-    }
-  }
-
   static {
-    addProviderOnce(new EdDSASecurityProvider()); // for ed25519-sha3 crypto
-    addProviderOnce(new BouncyCastleProvider());  // for sha3 hash
+    Security.addProvider(new EdDSASecurityProvider()); // for ed25519-sha3 crypto
+    Security.addProvider(new BouncyCastleProvider());  // for sha3 hash
   }
 
   public Signature getSignature(SignatureTypeEnum type)

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/SignatureTypeEnum.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/SignatureTypeEnum.java
@@ -1,6 +1,5 @@
 package jp.co.soramitsu.sora.crypto.common;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,13 +22,4 @@ public enum SignatureTypeEnum {
   @Getter
   private final String provider;
 
-//  @JsonCreator
-//  public static SignatureTypeEnum fromString(String v) {
-//    for (SignatureTypeEnum e : values()) {
-//      if (e.signatureType.equals(v)) {
-//        return e;
-//      }
-//    }
-//    throw new IllegalArgumentException("invalid string value passed: " + v);
-//  }
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/SignatureTypeEnum.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/SignatureTypeEnum.java
@@ -1,0 +1,35 @@
+package jp.co.soramitsu.sora.crypto.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public enum SignatureTypeEnum {
+  Ed25519Sha3Signature(
+      Consts.ED25519_SHA3_SIGNATURE,
+      Consts.ED25519_SHA3_VERIFICATION_KEY,
+      "EdDSA", "EdDSA"
+  );
+
+  @Getter
+  @JsonValue
+  private final String signatureType;
+  @Getter
+  private final String keyType;
+  @Getter
+  private final String algorithm;
+  @Getter
+  private final String provider;
+
+//  @JsonCreator
+//  public static SignatureTypeEnum fromString(String v) {
+//    for (SignatureTypeEnum e : values()) {
+//      if (e.signatureType.equals(v)) {
+//        return e;
+//      }
+//    }
+//    throw new IllegalArgumentException("invalid string value passed: " + v);
+//  }
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/SignatureTypeEnum.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/SignatureTypeEnum.java
@@ -6,6 +6,7 @@ import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@Getter
 @AllArgsConstructor
 public enum SignatureTypeEnum {
   Ed25519Sha3Signature(
@@ -15,14 +16,10 @@ public enum SignatureTypeEnum {
       EdDSASecurityProvider.PROVIDER_NAME
   );
 
-  @Getter
   @JsonValue
   private final String signatureType;
-  @Getter
   private final String keyType;
-  @Getter
   private final String algorithm;
-  @Getter
   private final String provider;
 
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/SignatureTypeEnum.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/SignatureTypeEnum.java
@@ -1,6 +1,8 @@
 package jp.co.soramitsu.sora.crypto.common;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import jp.co.soramitsu.crypto.ed25519.EdDSAEngine;
+import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,7 +11,8 @@ public enum SignatureTypeEnum {
   Ed25519Sha3Signature(
       Consts.ED25519_SHA3_SIGNATURE,
       Consts.ED25519_SHA3_VERIFICATION_KEY,
-      "EdDSA", "EdDSA"
+      EdDSAEngine.SIGNATURE_ALGORITHM,
+      EdDSASecurityProvider.PROVIDER_NAME
   );
 
   @Getter

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/SignatureTypeEnum.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/SignatureTypeEnum.java
@@ -11,14 +11,14 @@ import lombok.Getter;
 public enum SignatureTypeEnum {
   Ed25519Sha3Signature(
       Consts.ED25519_SHA3_SIGNATURE,
-      Consts.ED25519_SHA3_VERIFICATION_KEY,
+      KeyTypeEnum.Ed25519Sha3,
       EdDSAEngine.SIGNATURE_ALGORITHM,
       EdDSASecurityProvider.PROVIDER_NAME
   );
 
   @JsonValue
   private final String signatureType;
-  private final String keyType;
+  private final KeyTypeEnum keyType;
   private final String algorithm;
   private final String provider;
 

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/SignatureTypeEnum.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/SignatureTypeEnum.java
@@ -3,11 +3,14 @@ package jp.co.soramitsu.sora.crypto.common;
 import com.fasterxml.jackson.annotation.JsonValue;
 import jp.co.soramitsu.crypto.ed25519.EdDSAEngine;
 import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.experimental.FieldDefaults;
 
 @Getter
 @AllArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public enum SignatureTypeEnum {
   Ed25519Sha3Signature(
       Consts.ED25519_SHA3_SIGNATURE,
@@ -17,9 +20,9 @@ public enum SignatureTypeEnum {
   );
 
   @JsonValue
-  private final String signatureType;
-  private final KeyTypeEnum keyType;
-  private final String algorithm;
-  private final String provider;
+  String signatureType;
+  KeyTypeEnum keyType;
+  String algorithm;
+  String provider;
 
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/proof/HexValueDeserializer.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/proof/HexValueDeserializer.java
@@ -1,0 +1,19 @@
+package jp.co.soramitsu.sora.crypto.proof;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import javax.xml.bind.DatatypeConverter;
+
+public class HexValueDeserializer extends JsonDeserializer<byte[]> {
+
+  /**
+   * @throws IllegalArgumentException when input data is not hex
+   */
+  @Override
+  public byte[] deserialize(JsonParser p, DeserializationContext ctxt)
+      throws IOException {
+    return DatatypeConverter.parseHexBinary(p.getText());
+  }
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/proof/HexValueSerializer.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/proof/HexValueSerializer.java
@@ -1,0 +1,16 @@
+package jp.co.soramitsu.sora.crypto.proof;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import javax.xml.bind.DatatypeConverter;
+
+public class HexValueSerializer extends JsonSerializer<byte[]> {
+
+  @Override
+  public void serialize(byte[] value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+    gen.writeString(DatatypeConverter.printHexBinary(value));
+  }
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/proof/Options.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/proof/Options.java
@@ -2,13 +2,15 @@ package jp.co.soramitsu.sora.crypto.proof;
 
 import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import lombok.ToString;
 
-@Data
 @AllArgsConstructor
 @NoArgsConstructor
+@ToString
+@Getter
 public class Options {
 
   @NonNull

--- a/src/main/java/jp/co/soramitsu/sora/crypto/proof/Options.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/proof/Options.java
@@ -1,16 +1,13 @@
 package jp.co.soramitsu.sora.crypto.proof;
 
+import javax.validation.constraints.NotBlank;
 import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.Data;
 import lombok.NonNull;
-import lombok.ToString;
 
+@Data
 @AllArgsConstructor
-@NoArgsConstructor
-@ToString
-@Getter
 public class Options {
 
   @NonNull
@@ -19,13 +16,13 @@ public class Options {
   /**
    * ISO8601 time.
    */
-  @NonNull
+  @NotBlank
   private String created;
 
-  @NonNull
+  @NotBlank
   private String creator;
 
-  @NonNull
+  @NotBlank
   private String nonce;
 
   private String purpose;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/proof/Options.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/proof/Options.java
@@ -1,0 +1,30 @@
+package jp.co.soramitsu.sora.crypto.proof;
+
+import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Options {
+
+  @NonNull
+  private SignatureTypeEnum type;
+
+  /**
+   * ISO8601 time.
+   */
+  @NonNull
+  private String created;
+
+  @NonNull
+  private String creator;
+
+  @NonNull
+  private String nonce;
+
+  private String purpose;
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/proof/Proof.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/proof/Proof.java
@@ -1,0 +1,44 @@
+package jp.co.soramitsu.sora.crypto.proof;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class Proof extends Options {
+
+  public Proof(Options options, byte[] signatureValue) {
+    super(
+        options.getType(),
+        options.getCreated(),
+        options.getCreator(),
+        options.getNonce(),
+        options.getPurpose()
+    );
+    this.signatureValue = signatureValue;
+  }
+
+  @JsonCreator
+  public Proof(
+      @NonNull @JsonProperty("type") SignatureTypeEnum type,
+      @NonNull @JsonProperty("created") String created,
+      @NonNull @JsonProperty("creator") String creator,
+      @NonNull @JsonProperty("nonce") String nonce,
+      @JsonProperty("purpose") String purpose,
+      @NonNull @JsonProperty("signatureValue") byte[] signatureValue
+  ) {
+    super(type, created, creator, nonce, purpose);
+    this.signatureValue = signatureValue;
+  }
+
+  @NonNull
+  @JsonSerialize(using = HexValueSerializer.class)
+  @JsonDeserialize(using = HexValueDeserializer.class)
+  private byte[] signatureValue;
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/proof/Proof.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/proof/Proof.java
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NonNull;
+import lombok.ToString;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
+@ToString
+@Getter
 public class Proof extends Options {
 
   @NonNull
@@ -41,6 +41,4 @@ public class Proof extends Options {
     super(type, created, creator, nonce, purpose);
     this.signatureValue = signatureValue;
   }
-
-
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/proof/Proof.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/proof/Proof.java
@@ -13,6 +13,11 @@ import lombok.NonNull;
 @EqualsAndHashCode(callSuper = true)
 public class Proof extends Options {
 
+  @NonNull
+  @JsonSerialize(using = HexValueSerializer.class)
+  @JsonDeserialize(using = HexValueDeserializer.class)
+  private byte[] signatureValue;
+
   public Proof(Options options, byte[] signatureValue) {
     super(
         options.getType(),
@@ -37,8 +42,5 @@ public class Proof extends Options {
     this.signatureValue = signatureValue;
   }
 
-  @NonNull
-  @JsonSerialize(using = HexValueSerializer.class)
-  @JsonDeserialize(using = HexValueDeserializer.class)
-  private byte[] signatureValue;
+
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/proof/Proof.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/proof/Proof.java
@@ -4,13 +4,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import javax.validation.constraints.NotBlank;
 import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum;
-import lombok.Getter;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NonNull;
-import lombok.ToString;
 
-@ToString
-@Getter
+@EqualsAndHashCode(callSuper = true)
+@Data
 public class Proof extends Options {
 
   @NonNull
@@ -32,9 +33,9 @@ public class Proof extends Options {
   @JsonCreator
   public Proof(
       @NonNull @JsonProperty("type") SignatureTypeEnum type,
-      @NonNull @JsonProperty("created") String created,
-      @NonNull @JsonProperty("creator") String creator,
-      @NonNull @JsonProperty("nonce") String nonce,
+      @NotBlank @JsonProperty("created") String created,
+      @NotBlank @JsonProperty("creator") String creator,
+      @NotBlank @JsonProperty("nonce") String nonce,
       @JsonProperty("purpose") String purpose,
       @NonNull @JsonProperty("signatureValue") byte[] signatureValue
   ) {

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/JSONCanonizer.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/JSONCanonizer.java
@@ -1,0 +1,14 @@
+package jp.co.soramitsu.sora.crypto.service;
+
+import java.io.IOException;
+
+public interface JSONCanonizer {
+
+  /**
+   * Canonization - is a term for "stable serialization".
+   *
+   * @param obj arbitrary POJO or {@link com.fasterxml.jackson.databind.JsonNode}
+   * @throws IOException if input argument can not be canonized
+   */
+  byte[] canonize(final Object obj) throws IOException;
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/JSONSigner.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/JSONSigner.java
@@ -1,0 +1,28 @@
+package jp.co.soramitsu.sora.crypto.service;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.security.Signature;
+import java.security.SignatureException;
+import jp.co.soramitsu.sora.crypto.proof.Options;
+
+
+public interface JSONSigner {
+
+  /**
+   * Sign input object with given signature algorithm and options.
+   *
+   * @param object input key-value object. Can be Jackson Tree (JsonNode, ObjectNode...), POJO, or
+   * Map<String, Object>
+   * @param signature signature algorithm, initialized for signing. Example:
+   * <code>
+   * Signature sig = Signature.getInstance(...); sig.initSign(privateKey, new SecureRandom())
+   * </code>
+   * @param options Signature options
+   */
+  ObjectNode sign(
+      Object object,
+      Signature signature,
+      Options options
+  ) throws SignatureException, IOException;
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/JSONVerifier.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/JSONVerifier.java
@@ -1,0 +1,21 @@
+package jp.co.soramitsu.sora.crypto.service;
+
+import java.io.IOException;
+import java.security.Signature;
+import java.security.SignatureException;
+
+public interface JSONVerifier {
+
+  /**
+   * Verifies proof node in the <code>root</code> JSON with <code>publicKey</code>
+   *
+   * @param root JSON node, that contains "proof" key
+   * @return true if proof is valid, false otherwise
+   * @throws IllegalArgumentException is thrown when "proof"."type" is not implemented.
+   * @throws SignatureException should never be thrown. If thrown, it is evidence of programming
+   * error (signature provider is not initialized with sign or verify)
+   */
+  boolean verify(Object root, Signature signature)
+      throws IOException, SignatureException;
+
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONCanonizerWithOneCoding.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONCanonizerWithOneCoding.java
@@ -1,0 +1,19 @@
+package jp.co.soramitsu.sora.crypto.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import jp.co.soramitsu.jackson.OneCodeMapper;
+import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
+import lombok.NoArgsConstructor;
+
+
+@NoArgsConstructor
+public class JSONCanonizerWithOneCoding implements JSONCanonizer {
+
+  private ObjectMapper mapper = new OneCodeMapper();
+
+  @Override
+  public byte[] canonize(Object obj) throws IOException {
+    return mapper.writeValueAsBytes(obj);
+  }
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONCanonizerWithOneCoding.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONCanonizerWithOneCoding.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class JSONCanonizerWithOneCoding implements JSONCanonizer {
 
-  private ObjectMapper mapper = new OneCodeMapper();
+  private final ObjectMapper mapper = new OneCodeMapper();
 
   @Override
   public byte[] canonize(Object obj) throws IOException {

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImpl.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImpl.java
@@ -1,0 +1,57 @@
+package jp.co.soramitsu.sora.crypto.service.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.security.Signature;
+import java.security.SignatureException;
+import jp.co.soramitsu.sora.common.Util;
+import jp.co.soramitsu.sora.crypto.common.Consts;
+import jp.co.soramitsu.sora.crypto.proof.Options;
+import jp.co.soramitsu.sora.crypto.proof.Proof;
+import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
+import jp.co.soramitsu.sora.crypto.service.JSONSigner;
+import lombok.NonNull;
+import lombok.Value;
+
+
+@Value
+public class JSONSignerImpl implements JSONSigner {
+
+  private final JSONCanonizer canonizer;
+  private final ObjectMapper mapper;
+
+  @Override
+  public ObjectNode sign(
+      @NonNull Object root,
+      @NonNull Signature signature,
+      @NonNull Options options
+  ) throws SignatureException, IOException {
+
+    String type = options.getType().getAlgorithm();
+    if (!type.equals(signature.getAlgorithm())) {
+      throw new SignatureException(
+          String
+              .format("options (%s) and signature (%s) have different signature algorithms", type,
+                  signature.getAlgorithm())
+      );
+    }
+
+    ObjectNode jsonDocument = mapper.valueToTree(root);
+    ObjectNode output = Util.deepCopyWithoutProofNode(jsonDocument);
+
+    // hash input json and sign this hash
+    byte[] prepared = Util.serializeWithOptions(this.canonizer, output, options);
+    signature.update(prepared);
+    byte[] sig = signature.sign();
+
+    // insert "proof" node into json
+    Proof proof = new Proof(options, sig);
+    JsonNode proofNode = mapper.valueToTree(proof);
+    output.set(Consts.PROOF_KEY, proofNode);
+
+    // return signed JSON
+    return output;
+  }
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImpl.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImpl.java
@@ -12,11 +12,11 @@ import jp.co.soramitsu.sora.crypto.proof.Options;
 import jp.co.soramitsu.sora.crypto.proof.Proof;
 import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
 import jp.co.soramitsu.sora.crypto.service.JSONSigner;
+import lombok.AllArgsConstructor;
 import lombok.NonNull;
-import lombok.Value;
 
 
-@Value
+@AllArgsConstructor
 public class JSONSignerImpl implements JSONSigner {
 
   private final JSONCanonizer canonizer;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImpl.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImpl.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.security.Signature;
 import java.security.SignatureException;
-import javax.xml.bind.DatatypeConverter;
 import jp.co.soramitsu.sora.common.Util;
 import jp.co.soramitsu.sora.crypto.common.Consts;
 import jp.co.soramitsu.sora.crypto.proof.Options;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImpl.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImpl.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.security.Signature;
 import java.security.SignatureException;
+import javax.xml.bind.DatatypeConverter;
 import jp.co.soramitsu.sora.common.Util;
 import jp.co.soramitsu.sora.crypto.common.Consts;
 import jp.co.soramitsu.sora.crypto.proof.Options;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImpl.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImpl.java
@@ -12,15 +12,19 @@ import jp.co.soramitsu.sora.crypto.proof.Options;
 import jp.co.soramitsu.sora.crypto.proof.Proof;
 import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
 import jp.co.soramitsu.sora.crypto.service.JSONSigner;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
+import lombok.experimental.FieldDefaults;
 
 
 @AllArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+
 public class JSONSignerImpl implements JSONSigner {
 
-  private final JSONCanonizer canonizer;
-  private final ObjectMapper mapper;
+  JSONCanonizer canonizer;
+  ObjectMapper mapper;
 
   private byte[] createSignature(ObjectNode root, Signature signature, Options options)
       throws SignatureException, IOException {
@@ -29,7 +33,6 @@ public class JSONSignerImpl implements JSONSigner {
     signature.update(prepared);
     return signature.sign();
   }
-
 
 
   private void setProof(ObjectNode output, Proof proof) {

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImpl.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImpl.java
@@ -51,11 +51,9 @@ public class JSONSignerImpl implements JSONSigner {
 
     byte[] sig = createSignature(output, signature, options);
 
-    // insert "proof" node into json
     Proof proof = new Proof(options, sig);
     setProof(output, proof);
 
-    // return signed JSON
     return output;
   }
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImpl.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImpl.java
@@ -30,7 +30,6 @@ public class JSONVerifierImpl implements JSONVerifier {
       return false;
     }
 
-    // read proof
     JsonNode proofNode = root.get(Consts.PROOF_KEY);
     Proof proof = mapper.treeToValue(proofNode, Proof.class);
     Options options = new Options(
@@ -43,11 +42,9 @@ public class JSONVerifierImpl implements JSONVerifier {
 
     Util.verifyAlgorithmType(options, signature);
 
-    // sanitize and serialize JSON
     ObjectNode out = Util.deepCopyWithoutProofNode(root);
     byte[] prepared = Util.serializeWithOptions(this.canonizer, out, options);
 
-    // verify signature
     signature.update(prepared); // throws SignatureException
     return signature.verify(proof.getSignatureValue());
   }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImpl.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImpl.java
@@ -41,6 +41,8 @@ public class JSONVerifierImpl implements JSONVerifier {
         proof.getPurpose()
     );
 
+    Util.verifyAlgorithmType(options, signature);
+
     // sanitize and serialize JSON
     ObjectNode out = Util.deepCopyWithoutProofNode(root);
     byte[] prepared = Util.serializeWithOptions(this.canonizer, out, options);

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImpl.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImpl.java
@@ -8,6 +8,7 @@ import java.security.Signature;
 import java.security.SignatureException;
 import jp.co.soramitsu.sora.common.Util;
 import jp.co.soramitsu.sora.crypto.common.Consts;
+import jp.co.soramitsu.sora.crypto.proof.Options;
 import jp.co.soramitsu.sora.crypto.proof.Proof;
 import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
 import jp.co.soramitsu.sora.crypto.service.JSONVerifier;
@@ -32,10 +33,17 @@ public class JSONVerifierImpl implements JSONVerifier {
     // read proof
     JsonNode proofNode = root.get(Consts.PROOF_KEY);
     Proof proof = mapper.treeToValue(proofNode, Proof.class);
+    Options options = new Options(
+        proof.getType(),
+        proof.getCreated(),
+        proof.getCreator(),
+        proof.getNonce(),
+        proof.getPurpose()
+    );
 
     // sanitize and serialize JSON
     ObjectNode out = Util.deepCopyWithoutProofNode(root);
-    byte[] prepared = Util.serializeWithOptions(this.canonizer, out, proof);
+    byte[] prepared = Util.serializeWithOptions(this.canonizer, out, options);
 
     // verify signature
     signature.update(prepared); // throws SignatureException

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImpl.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImpl.java
@@ -12,14 +12,17 @@ import jp.co.soramitsu.sora.crypto.proof.Options;
 import jp.co.soramitsu.sora.crypto.proof.Proof;
 import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
 import jp.co.soramitsu.sora.crypto.service.JSONVerifier;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.experimental.FieldDefaults;
 
 
 @AllArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class JSONVerifierImpl implements JSONVerifier {
 
-  private final JSONCanonizer canonizer;
-  private final ObjectMapper mapper;
+  JSONCanonizer canonizer;
+  ObjectMapper mapper;
 
   @Override
   public boolean verify(Object object, Signature signature)

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImpl.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImpl.java
@@ -11,10 +11,10 @@ import jp.co.soramitsu.sora.crypto.common.Consts;
 import jp.co.soramitsu.sora.crypto.proof.Proof;
 import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
 import jp.co.soramitsu.sora.crypto.service.JSONVerifier;
-import lombok.Value;
+import lombok.AllArgsConstructor;
 
 
-@Value
+@AllArgsConstructor
 public class JSONVerifierImpl implements JSONVerifier {
 
   private final JSONCanonizer canonizer;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImpl.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImpl.java
@@ -1,0 +1,44 @@
+package jp.co.soramitsu.sora.crypto.service.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.security.Signature;
+import java.security.SignatureException;
+import jp.co.soramitsu.sora.common.Util;
+import jp.co.soramitsu.sora.crypto.common.Consts;
+import jp.co.soramitsu.sora.crypto.proof.Proof;
+import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
+import jp.co.soramitsu.sora.crypto.service.JSONVerifier;
+import lombok.Value;
+
+
+@Value
+public class JSONVerifierImpl implements JSONVerifier {
+
+  private final JSONCanonizer canonizer;
+  private final ObjectMapper mapper;
+
+  @Override
+  public boolean verify(Object object, Signature signature)
+      throws IOException, SignatureException {
+    ObjectNode root = mapper.valueToTree(object);
+
+    if (!root.hasNonNull(Consts.PROOF_KEY)) {
+      return false;
+    }
+
+    // read proof
+    JsonNode proofNode = root.get(Consts.PROOF_KEY);
+    Proof proof = mapper.treeToValue(proofNode, Proof.class);
+
+    // sanitize and serialize JSON
+    ObjectNode out = Util.deepCopyWithoutProofNode(root);
+    byte[] prepared = Util.serializeWithOptions(this.canonizer, out, proof);
+
+    // verify signature
+    signature.update(prepared); // throws SignatureException
+    return signature.verify(proof.getSignatureValue());
+  }
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuite.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuite.java
@@ -27,6 +27,8 @@ public class JSONEd25519Sha3SignatureSuite {
 
   private Signature signature;
 
+  public static final SignatureTypeEnum type = SignatureTypeEnum.Ed25519Sha3Signature;
+
   /**
    * Default constructor for Ed25519 with Sha3 signature algorithm, OneCoding as canonicalization
    * algorithm, and default JSON ObjectMapper.
@@ -50,7 +52,7 @@ public class JSONEd25519Sha3SignatureSuite {
   ) {
     this.signer = new JSONSignerImpl(canonizer, mapper);
     this.verifier = new JSONVerifierImpl(canonizer, mapper);
-    this.signature = provider.getSignature(SignatureTypeEnum.Ed25519Sha3Signature);
+    this.signature = provider.getSignature(type);
   }
 
   /**

--- a/src/main/java/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuite.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuite.java
@@ -1,0 +1,89 @@
+package jp.co.soramitsu.sora.crypto.signature.suite;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.Signature;
+import java.security.SignatureException;
+import jp.co.soramitsu.crypto.ed25519.EdDSAPrivateKey;
+import jp.co.soramitsu.crypto.ed25519.EdDSAPublicKey;
+import jp.co.soramitsu.sora.crypto.common.SecurityProvider;
+import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum;
+import jp.co.soramitsu.sora.crypto.proof.Options;
+import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
+import jp.co.soramitsu.sora.crypto.service.JSONSigner;
+import jp.co.soramitsu.sora.crypto.service.JSONVerifier;
+import jp.co.soramitsu.sora.crypto.service.impl.JSONCanonizerWithOneCoding;
+import jp.co.soramitsu.sora.crypto.service.impl.JSONSignerImpl;
+import jp.co.soramitsu.sora.crypto.service.impl.JSONVerifierImpl;
+import lombok.SneakyThrows;
+
+
+public class JSONEd25519Sha3SignatureSuite {
+
+  private final JSONSigner signer;
+  private final JSONVerifier verifier;
+
+  private Signature signature;
+
+  /**
+   * Default constructor for Ed25519 with Sha3 signature algorithm, OneCoding as canonicalization
+   * algorithm, and default JSON ObjectMapper.
+   */
+  public JSONEd25519Sha3SignatureSuite() {
+    this(new SecurityProvider(), new JSONCanonizerWithOneCoding(), new ObjectMapper());
+  }
+
+  /**
+   * Constructor for mocks injection.
+   *
+   * @param provider security provider. Mockable non-static wrapper for static Signature methods.
+   * @param canonizer canonicalization algorithm.
+   * @param mapper JSON ObjectMapper
+   */
+  @SneakyThrows
+  public JSONEd25519Sha3SignatureSuite(
+      SecurityProvider provider,
+      JSONCanonizer canonizer,
+      ObjectMapper mapper
+  ) {
+    this.signer = new JSONSignerImpl(canonizer, mapper);
+    this.verifier = new JSONVerifierImpl(canonizer, mapper);
+    this.signature = provider.getSignature(SignatureTypeEnum.Ed25519Sha3Signature);
+  }
+
+  /**
+   * Sign Object and return signed JSON.
+   *
+   * @param object JsonNode, Map<String, Object> or POJO; i.e. anything that can be processed with
+   * ObjectMapper
+   * @param privateKey EdDSA private key
+   * @param options signature options
+   * @return signed JSON with key "proof". Previous proofs will be erased.
+   * @throws IOException when input JSON can not be processed
+   */
+  @SneakyThrows({SignatureException.class, InvalidKeyException.class})  // never thrown
+  // these exceptions are never thrown
+  public ObjectNode sign(Object object, EdDSAPrivateKey privateKey, Options options)
+      throws IOException {
+    signature.initSign(privateKey);
+    return signer.sign(object, signature, options);
+  }
+
+  /**
+   * Verify signed Object
+   *
+   * @param root JsonNode, Map<String, Object> or POJO; i.e. anything that can be processed with
+   * ObjectMapper
+   * @param publicKey EdDSA public key
+   * @return true if <code>root</code> has cryptographically valid "proof" node; false otherwise.
+   * @throws IOException when input JSON can not be processed
+   */
+  @SneakyThrows({SignatureException.class, InvalidKeyException.class})  // never thrown
+  public boolean verify(Object root, EdDSAPublicKey publicKey)
+      throws IOException {
+    signature.initVerify(publicKey);
+    return verifier.verify(root, signature);
+  }
+}

--- a/src/main/java/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuite.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuite.java
@@ -62,11 +62,13 @@ public class JSONEd25519Sha3SignatureSuite {
    * @param options signature options
    * @return signed JSON with key "proof". Previous proofs will be erased.
    * @throws IOException when input JSON can not be processed
+   * @throws SignatureException when options signature type is not the same as received crypto type
+   * from {@link SecurityProvider}
    */
-  @SneakyThrows({SignatureException.class, InvalidKeyException.class})  // never thrown
+  @SneakyThrows({InvalidKeyException.class})  // never thrown
   // these exceptions are never thrown
   public ObjectNode sign(Object object, EdDSAPrivateKey privateKey, Options options)
-      throws IOException {
+      throws IOException, SignatureException {
     signature.initSign(privateKey);
     return signer.sign(object, signature, options);
   }

--- a/src/main/java/jp/co/soramitsu/sora/json/BadJsonException.java
+++ b/src/main/java/jp/co/soramitsu/sora/json/BadJsonException.java
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class BadJsonException extends RuntimeException {
 
-  public BadJsonException(JsonNode node){
+  public BadJsonException(JsonNode node) {
     super("Bad json: " + node);
   }
 
-  public BadJsonException(Exception e){
+  public BadJsonException(Exception e) {
     super(e);
   }
 

--- a/src/main/java/jp/co/soramitsu/sora/json/Flattener.java
+++ b/src/main/java/jp/co/soramitsu/sora/json/Flattener.java
@@ -95,7 +95,7 @@ public class Flattener {
       if (!value.isValueNode() &&  // not value node
           // and not empty object or empty array
           (value.size() != 0 && (value.isArray() || value.isObject()))
-          ) {
+      ) {
         return false;
       }
 

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/GroovyCryptoProvidersTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/GroovyCryptoProvidersTest.groovy
@@ -1,10 +1,12 @@
 package jp.co.soramitsu.sora.crypto
 
 import jp.co.soramitsu.crypto.ed25519.EdDSAEngine
+import jp.co.soramitsu.crypto.ed25519.EdDSAKey
 import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider
 import org.spongycastle.jce.provider.BouncyCastleProvider
 import spock.lang.Specification
 
+import java.security.KeyPairGenerator
 import java.security.MessageDigest
 import java.security.Security
 import java.security.Signature
@@ -16,6 +18,8 @@ class GroovyCryptoProvidersTest extends Specification {
         Security.addProvider(new EdDSASecurityProvider())
         Signature.getInstance(EdDSAEngine.SIGNATURE_ALGORITHM, EdDSASecurityProvider.PROVIDER_NAME)
         Signature.getInstance(EdDSAEngine.SIGNATURE_ALGORITHM)
+        KeyPairGenerator.getInstance(EdDSAKey.KEY_ALGORITHM, EdDSASecurityProvider.PROVIDER_NAME)
+        KeyPairGenerator.getInstance(EdDSAKey.KEY_ALGORITHM)
 
         then:
         noExceptionThrown()

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/GroovyCryptoProvidersTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/GroovyCryptoProvidersTest.groovy
@@ -1,0 +1,31 @@
+package jp.co.soramitsu.sora.crypto
+
+import jp.co.soramitsu.crypto.ed25519.EdDSAEngine
+import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider
+import org.spongycastle.jce.provider.BouncyCastleProvider
+import spock.lang.Specification
+
+import java.security.*
+
+class GroovyCryptoProvidersTest extends Specification {
+
+    def "has ed25519-sha3"() {
+        when:
+        Security.addProvider(new EdDSASecurityProvider())
+        Signature.getInstance(EdDSAEngine.SIGNATURE_ALGORITHM, EdDSASecurityProvider.PROVIDER_NAME)
+        Signature.getInstance(EdDSAEngine.SIGNATURE_ALGORITHM)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "has bouncycastle"() {
+        when:
+        Security.addProvider(new BouncyCastleProvider())
+        MessageDigest.getInstance("SHA3-256", BouncyCastleProvider.PROVIDER_NAME)
+        MessageDigest.getInstance("SHA3-256")
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/GroovyCryptoProvidersTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/GroovyCryptoProvidersTest.groovy
@@ -5,7 +5,9 @@ import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider
 import org.spongycastle.jce.provider.BouncyCastleProvider
 import spock.lang.Specification
 
-import java.security.*
+import java.security.MessageDigest
+import java.security.Security
+import java.security.Signature
 
 class GroovyCryptoProvidersTest extends Specification {
 

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/service/impl/JSONCanonizerWithOneCodingTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/service/impl/JSONCanonizerWithOneCodingTest.groovy
@@ -1,0 +1,25 @@
+package jp.co.soramitsu.sora.crypto.service.impl
+
+import jp.co.soramitsu.sora.crypto.service.JSONCanonizer
+import spock.lang.Specification
+
+
+class JSONCanonizerWithOneCodingTest extends Specification {
+
+    def "canonizer works"() {
+        given:
+        JSONCanonizer canonizer = new JSONCanonizerWithOneCoding()
+
+        when:
+        def actual = canonizer.canonize(input)
+
+        then:
+        actual == expected
+
+        where:
+
+        input              | expected
+        ["a": 1, "b": "2"] | "d1:ai1e1:b1:2e" as byte[]
+    }
+
+}

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImplTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImplTest.groovy
@@ -1,0 +1,68 @@
+package jp.co.soramitsu.sora.crypto.service.impl
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import jp.co.soramitsu.sora.common.MockSignature
+import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum
+import jp.co.soramitsu.sora.crypto.proof.Options
+import jp.co.soramitsu.sora.crypto.proof.Proof
+import jp.co.soramitsu.sora.crypto.service.JSONCanonizer
+import jp.co.soramitsu.sora.crypto.service.JSONSigner
+import spock.lang.Specification
+
+import java.security.PrivateKey
+import java.security.Signature
+
+class JSONSignerImplTest extends Specification {
+
+    def "sign unit test"() {
+        given:
+        byte[] signatureBytes = "signature" as byte[]
+        Map<String, Integer> object = ["a": 1]
+        String proofNode = "valid"
+
+        ObjectMapper jsonMapper = Mock(ObjectMapper) {
+            valueToTree(object) >> {
+                new ObjectMapper().valueToTree(object)
+            }
+
+            valueToTree(_ as Proof) >> {
+                new ObjectMapper().valueToTree(proofNode)
+            }
+        }
+
+
+        JSONCanonizer canonizer = Mock(JSONCanonizer) {
+            canonize(_ as Options) >> { "options" as byte[] }
+            canonize(_ as ObjectNode) >> { "objectNode" as byte[] }
+        }
+
+        def serialized = "objectNodeoptions" as byte[]
+
+        JSONSigner signer = new JSONSignerImpl(canonizer, jsonMapper)
+
+        Signature signature = Spy(MockSignature, constructorArgs: [
+                SignatureTypeEnum.Ed25519Sha3Signature.getAlgorithm(), signatureBytes
+        ])
+        signature.initSign(Stub(PrivateKey))
+
+        Options options = new Options(
+                SignatureTypeEnum.Ed25519Sha3Signature,
+                "created",
+                "creator",
+                "nonce",
+                "purpose"
+        )
+
+        when:
+        ObjectNode out = signer.sign(object, signature, options)
+
+        then:
+        interaction {
+            1 * signature.engineUpdate(serialized, 0, serialized.length)
+            1 * signature.engineSign() >> { signatureBytes }
+        }
+
+        out.toString() == '{"a":1,"proof":"valid"}'
+    }
+}

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImplTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImplTest.groovy
@@ -1,0 +1,95 @@
+package jp.co.soramitsu.sora.crypto.service.impl
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import jp.co.soramitsu.sora.common.MockSignature
+import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum
+import jp.co.soramitsu.sora.crypto.proof.Options
+import jp.co.soramitsu.sora.crypto.proof.Proof
+import jp.co.soramitsu.sora.crypto.service.JSONCanonizer
+import jp.co.soramitsu.sora.crypto.service.JSONVerifier
+import spock.lang.Specification
+
+import java.security.PublicKey
+import java.security.Signature
+
+
+class JSONVerifierImplTest extends Specification {
+
+    def "verify unit test"() {
+        given:
+        def valid = false
+        byte[] signatureBytes = "signature" as byte[]
+        String proofNode = "valid"
+
+        Map<String, Integer> noproof = ["noproof": 1]
+        Map<String, Object> withproofButIncorrect = ["proof": [
+                "signatureValue": "0123456789ABCDEF"
+        ]]
+
+        Options options = new Options(
+                SignatureTypeEnum.Ed25519Sha3Signature,
+                "created",
+                "creator",
+                "nonce",
+                "purpose"
+        )
+
+        Proof proof = new Proof(options, "signature" as byte[])
+
+        Map<String, Object> withCorrectProof = ["proof": proof]
+
+
+        ObjectMapper jsonMapper = Spy(ObjectMapper) {
+            valueToTree(noproof) >> {
+                new ObjectMapper().valueToTree(noproof)
+            }
+
+            valueToTree(withproofButIncorrect) >> {
+                new ObjectMapper().valueToTree(withproofButIncorrect)
+            }
+
+            valueToTree(_ as Proof) >> {
+                new ObjectMapper().valueToTree(proofNode)
+            }
+        }
+
+
+        JSONCanonizer canonizer = Mock(JSONCanonizer) {
+            canonize(_ as Options) >> { "options" as byte[] }
+            canonize(_ as ObjectNode) >> { "objectNode" as byte[] }
+        }
+
+        JSONVerifier verifier = new JSONVerifierImpl(canonizer, jsonMapper)
+
+        Signature signature = Spy(MockSignature, constructorArgs: [
+                SignatureTypeEnum.Ed25519Sha3Signature.getAlgorithm(), signatureBytes
+        ])
+
+        signature.initVerify(Stub(PublicKey))
+
+
+
+        when: "input json has no proof key"
+        valid = verifier.verify(noproof, signature)
+
+        then: "proof is invalid"
+        !valid
+
+        when: "input json has proof without required fields"
+        verifier.verify(withproofButIncorrect, signature)
+
+        then: "can not read proof from json; exception"
+        thrown(IOException)
+
+        when: "input json has correct proof"
+        valid = verifier.verify(withCorrectProof, signature)
+
+        then: "proof is valid"
+        noExceptionThrown()
+        valid
+        interaction {
+            1 * signature.engineVerify(signatureBytes) >> { true }
+        }
+    }
+}

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuiteTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuiteTest.groovy
@@ -1,0 +1,75 @@
+package jp.co.soramitsu.sora.crypto.signature.suite
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import jp.co.soramitsu.crypto.ed25519.EdDSAPrivateKey
+import jp.co.soramitsu.crypto.ed25519.EdDSAPublicKey
+import jp.co.soramitsu.sora.common.MockSignature
+import jp.co.soramitsu.sora.crypto.common.SecurityProvider
+import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum
+import jp.co.soramitsu.sora.crypto.proof.Options
+import jp.co.soramitsu.sora.crypto.service.JSONCanonizer
+import spock.lang.Specification
+
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.Signature
+
+class JSONEd25519Sha3SignatureSuiteTest extends Specification {
+
+    def "ed25519 with sha3 signature suite unit test"() {
+        given:
+
+        def signatureBytes = "signature" as byte[]
+        def algorithm = SignatureTypeEnum.Ed25519Sha3Signature.getAlgorithm()
+
+        Signature signature = Spy(MockSignature, constructorArgs: [
+                algorithm,
+                signatureBytes
+        ])
+
+        SecurityProvider provider = Mock(SecurityProvider) {
+            getSignature(SignatureTypeEnum.Ed25519Sha3Signature) >> { signature }
+        }
+
+        ObjectMapper jsonMapper = Spy(ObjectMapper)
+
+        JSONCanonizer canonizer = Mock(JSONCanonizer) {
+            canonize(_ as Options) >> { "options" as byte[] }
+            canonize(_ as ObjectNode) >> { "objectNode" as byte[] }
+        }
+
+
+        JSONEd25519Sha3SignatureSuite suite = new JSONEd25519Sha3SignatureSuite(provider, canonizer, jsonMapper)
+
+        def object = [
+                "a": 1
+        ] as Map<String, Object>
+
+        PrivateKey privateKey = Stub(EdDSAPrivateKey)
+        PublicKey publicKey = Stub(EdDSAPublicKey)
+
+        Options options = new Options(
+                SignatureTypeEnum.Ed25519Sha3Signature,
+                "created",
+                "creator",
+                "nonce",
+                "purpose"
+        )
+
+
+        when: "sign JSON"
+        ObjectNode out = suite.sign(object, privateKey, options)
+        println(out)
+
+        then:
+        out.toString() == '{"a":1,"proof":{"type":"Ed25519Sha3Signature","created":"created","creator":"creator","nonce":"nonce","purpose":"purpose","signatureValue":"7369676E6174757265"}}'
+
+        when: "verify proof"
+        boolean valid = suite.verify(out, publicKey)
+
+        then: "proof is valid"
+        noExceptionThrown()
+        valid
+    }
+}

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuiteTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuiteTest.groovy
@@ -60,7 +60,6 @@ class JSONEd25519Sha3SignatureSuiteTest extends Specification {
 
         when: "sign JSON"
         ObjectNode out = suite.sign(object, privateKey, options)
-        println(out)
 
         then:
         out.toString() == '{"a":1,"proof":{"type":"Ed25519Sha3Signature","created":"created","creator":"creator","nonce":"nonce","purpose":"purpose","signatureValue":"7369676E6174757265"}}'

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuiteTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuiteTest.groovy
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
 import jp.co.soramitsu.crypto.ed25519.EdDSAPrivateKey
 import jp.co.soramitsu.crypto.ed25519.EdDSAPublicKey
-import jp.co.soramitsu.crypto.ed25519.KeyPairGenerator
 import jp.co.soramitsu.sora.common.MockSignature
 import jp.co.soramitsu.sora.crypto.common.Consts
+import jp.co.soramitsu.sora.crypto.common.KeyTypeEnum
 import jp.co.soramitsu.sora.crypto.common.SecurityProvider
 import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum
 import jp.co.soramitsu.sora.crypto.proof.Options
@@ -14,13 +14,14 @@ import jp.co.soramitsu.sora.crypto.service.JSONCanonizer
 import spock.lang.Specification
 
 import java.security.KeyPair
+import java.security.KeyPairGenerator
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.Signature
 
 class JSONEd25519Sha3SignatureSuiteTest extends Specification {
 
-    def "ed25519 with sha3 signature suite unit test"() {
+    def "ed25519-sha3 signature suite unit test"() {
         given:
 
         def signatureBytes = "signature" as byte[]
@@ -78,6 +79,8 @@ class JSONEd25519Sha3SignatureSuiteTest extends Specification {
 
     def "ed25519-sha3 with onecoder integration test"() {
         given:
+        def securityProvider = new SecurityProvider()
+
         JSONEd25519Sha3SignatureSuite suite = new JSONEd25519Sha3SignatureSuite()
         def object = [
                 "a": 1
@@ -85,8 +88,7 @@ class JSONEd25519Sha3SignatureSuiteTest extends Specification {
 
 
         when: "generate a keypair"
-        // TODO: replace jp.co.soramitsu.crypto.ed25519.KeyPairGenerator with java.security.KeyPairGenerator
-        KeyPairGenerator generator = new KeyPairGenerator()
+        KeyPairGenerator generator = securityProvider.getKeyPairGenerator(KeyTypeEnum.Ed25519Sha3)
         KeyPair keyPair = generator.generateKeyPair()
 
         then: "EdDSA keypair is generated"

--- a/src/test/java/jp/co/soramitsu/sora/common/MockSignature.java
+++ b/src/test/java/jp/co/soramitsu/sora/common/MockSignature.java
@@ -20,22 +20,22 @@ public class MockSignature extends Signature {
 
   @Override
   protected void engineInitVerify(PublicKey publicKey) throws InvalidKeyException {
-
+    /* do nothing */
   }
 
   @Override
   protected void engineInitSign(PrivateKey privateKey) throws InvalidKeyException {
-
+    /* do nothing */
   }
 
   @Override
   protected void engineUpdate(byte b) throws SignatureException {
-
+    /* do nothing */
   }
 
   @Override
   protected void engineUpdate(byte[] b, int off, int len) throws SignatureException {
-
+    /* do nothing */
   }
 
   @Override
@@ -50,7 +50,7 @@ public class MockSignature extends Signature {
 
   @Override
   protected void engineSetParameter(String param, Object value) throws InvalidParameterException {
-
+    /* do nothing */
   }
 
   @Override

--- a/src/test/java/jp/co/soramitsu/sora/common/MockSignature.java
+++ b/src/test/java/jp/co/soramitsu/sora/common/MockSignature.java
@@ -1,0 +1,60 @@
+package jp.co.soramitsu.sora.common;
+
+import java.security.InvalidKeyException;
+import java.security.InvalidParameterException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.util.Arrays;
+
+public class MockSignature extends Signature {
+
+  private byte[] signature;
+
+  public MockSignature(String algorithm, byte[] signature) {
+    super(algorithm);
+
+    this.signature = signature;
+  }
+
+  @Override
+  protected void engineInitVerify(PublicKey publicKey) throws InvalidKeyException {
+
+  }
+
+  @Override
+  protected void engineInitSign(PrivateKey privateKey) throws InvalidKeyException {
+
+  }
+
+  @Override
+  protected void engineUpdate(byte b) throws SignatureException {
+
+  }
+
+  @Override
+  protected void engineUpdate(byte[] b, int off, int len) throws SignatureException {
+
+  }
+
+  @Override
+  protected byte[] engineSign() throws SignatureException {
+    return signature;
+  }
+
+  @Override
+  protected boolean engineVerify(byte[] sigBytes) throws SignatureException {
+    return Arrays.equals(sigBytes, signature);
+  }
+
+  @Override
+  protected void engineSetParameter(String param, Object value) throws InvalidParameterException {
+
+  }
+
+  @Override
+  protected Object engineGetParameter(String param) throws InvalidParameterException {
+    return null;
+  }
+}

--- a/src/test/java/jp/co/soramitsu/sora/crypto/CryptoProvidersTest.java
+++ b/src/test/java/jp/co/soramitsu/sora/crypto/CryptoProvidersTest.java
@@ -1,0 +1,36 @@
+package jp.co.soramitsu.sora.crypto;
+
+import java.security.KeyFactory;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Security;
+import java.security.Signature;
+import jp.co.soramitsu.crypto.ed25519.EdDSAEngine;
+import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider;
+import org.junit.Test;
+import org.spongycastle.jce.provider.BouncyCastleProvider;
+
+public class CryptoProvidersTest {
+
+  @Test
+  public void hasEd25519WithSha3() throws NoSuchProviderException, NoSuchAlgorithmException {
+    Security.addProvider(new EdDSASecurityProvider());
+
+    // no exception thrown
+    Signature.getInstance(EdDSAEngine.SIGNATURE_ALGORITHM, EdDSASecurityProvider.PROVIDER_NAME);
+    Signature.getInstance(EdDSAEngine.SIGNATURE_ALGORITHM);
+    KeyPairGenerator.getInstance("EdDSA", "EdDSA");
+    KeyFactory.getInstance("EdDSA", "EdDSA");
+  }
+
+  @Test
+  public void hasSha3() throws NoSuchAlgorithmException, NoSuchProviderException {
+    Security.addProvider(new BouncyCastleProvider());
+
+    // no exception thrown
+    MessageDigest.getInstance("SHA3-256", BouncyCastleProvider.PROVIDER_NAME);
+    MessageDigest.getInstance("SHA3-256");
+  }
+}

--- a/src/test/java/jp/co/soramitsu/sora/crypto/CryptoProvidersTest.java
+++ b/src/test/java/jp/co/soramitsu/sora/crypto/CryptoProvidersTest.java
@@ -1,5 +1,7 @@
 package jp.co.soramitsu.sora.crypto;
 
+import static org.junit.Assert.fail;
+
 import java.security.KeyFactory;
 import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
@@ -16,21 +18,29 @@ public class CryptoProvidersTest {
 
   @Test
   public void hasEd25519WithSha3() throws NoSuchProviderException, NoSuchAlgorithmException {
-    Security.addProvider(new EdDSASecurityProvider());
+    try {
+      Security.addProvider(new EdDSASecurityProvider());
 
-    // no exception thrown
-    Signature.getInstance(EdDSAEngine.SIGNATURE_ALGORITHM, EdDSASecurityProvider.PROVIDER_NAME);
-    Signature.getInstance(EdDSAEngine.SIGNATURE_ALGORITHM);
-    KeyPairGenerator.getInstance("EdDSA", "EdDSA");
-    KeyFactory.getInstance("EdDSA", "EdDSA");
+      // no exception thrown
+      Signature.getInstance(EdDSAEngine.SIGNATURE_ALGORITHM, EdDSASecurityProvider.PROVIDER_NAME);
+      Signature.getInstance(EdDSAEngine.SIGNATURE_ALGORITHM);
+      KeyPairGenerator.getInstance("EdDSA", "EdDSA");
+      KeyFactory.getInstance("EdDSA", "EdDSA");
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
   }
 
   @Test
   public void hasSha3() throws NoSuchAlgorithmException, NoSuchProviderException {
-    Security.addProvider(new BouncyCastleProvider());
+    try {
+      Security.addProvider(new BouncyCastleProvider());
 
-    // no exception thrown
-    MessageDigest.getInstance("SHA3-256", BouncyCastleProvider.PROVIDER_NAME);
-    MessageDigest.getInstance("SHA3-256");
+      // no exception thrown
+      MessageDigest.getInstance("SHA3-256", BouncyCastleProvider.PROVIDER_NAME);
+      MessageDigest.getInstance("SHA3-256");
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
   }
 }

--- a/src/test/java/jp/co/soramitsu/sora/crypto/CryptoProvidersTest.java
+++ b/src/test/java/jp/co/soramitsu/sora/crypto/CryptoProvidersTest.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.fail;
 import java.security.KeyFactory;
 import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.Security;
 import java.security.Signature;
 import jp.co.soramitsu.crypto.ed25519.EdDSAEngine;
@@ -17,7 +15,7 @@ import org.spongycastle.jce.provider.BouncyCastleProvider;
 public class CryptoProvidersTest {
 
   @Test
-  public void hasEd25519WithSha3() throws NoSuchProviderException, NoSuchAlgorithmException {
+  public void hasEd25519WithSha3() {
     try {
       Security.addProvider(new EdDSASecurityProvider());
 
@@ -32,7 +30,7 @@ public class CryptoProvidersTest {
   }
 
   @Test
-  public void hasSha3() throws NoSuchAlgorithmException, NoSuchProviderException {
+  public void hasSha3() {
     try {
       Security.addProvider(new BouncyCastleProvider());
 

--- a/src/test/java/jp/co/soramitsu/sora/crypto/JavaCryptoProvidersTest.java
+++ b/src/test/java/jp/co/soramitsu/sora/crypto/JavaCryptoProvidersTest.java
@@ -12,7 +12,7 @@ import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider;
 import org.junit.Test;
 import org.spongycastle.jce.provider.BouncyCastleProvider;
 
-public class CryptoProvidersTest {
+public class JavaCryptoProvidersTest {
 
   @Test
   public void hasEd25519WithSha3() {
@@ -22,8 +22,6 @@ public class CryptoProvidersTest {
       // no exception thrown
       Signature.getInstance(EdDSAEngine.SIGNATURE_ALGORITHM, EdDSASecurityProvider.PROVIDER_NAME);
       Signature.getInstance(EdDSAEngine.SIGNATURE_ALGORITHM);
-      KeyPairGenerator.getInstance("EdDSA", "EdDSA");
-      KeyFactory.getInstance("EdDSA", "EdDSA");
     } catch (Exception e) {
       fail(e.getMessage());
     }

--- a/src/test/java/jp/co/soramitsu/sora/crypto/JavaCryptoProvidersTest.java
+++ b/src/test/java/jp/co/soramitsu/sora/crypto/JavaCryptoProvidersTest.java
@@ -2,10 +2,12 @@ package jp.co.soramitsu.sora.crypto;
 
 import static org.junit.Assert.fail;
 
+import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
 import java.security.Security;
 import java.security.Signature;
 import jp.co.soramitsu.crypto.ed25519.EdDSAEngine;
+import jp.co.soramitsu.crypto.ed25519.EdDSAKey;
 import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider;
 import org.junit.Test;
 import org.spongycastle.jce.provider.BouncyCastleProvider;
@@ -20,6 +22,8 @@ public class JavaCryptoProvidersTest {
       // no exception thrown
       Signature.getInstance(EdDSAEngine.SIGNATURE_ALGORITHM, EdDSASecurityProvider.PROVIDER_NAME);
       Signature.getInstance(EdDSAEngine.SIGNATURE_ALGORITHM);
+      KeyPairGenerator.getInstance(EdDSAKey.KEY_ALGORITHM, EdDSASecurityProvider.PROVIDER_NAME);
+      KeyPairGenerator.getInstance(EdDSAKey.KEY_ALGORITHM);
     } catch (Exception e) {
       fail(e.getMessage());
     }

--- a/src/test/java/jp/co/soramitsu/sora/crypto/JavaCryptoProvidersTest.java
+++ b/src/test/java/jp/co/soramitsu/sora/crypto/JavaCryptoProvidersTest.java
@@ -2,8 +2,6 @@ package jp.co.soramitsu.sora.crypto;
 
 import static org.junit.Assert.fail;
 
-import java.security.KeyFactory;
-import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
 import java.security.Security;
 import java.security.Signature;


### PR DESCRIPTION
- https://soramitsu.atlassian.net/secure/RapidBoard.jspa?rapidView=36&projectKey=BSM&modal=detail&selectedIssue=BSM-75
- https://soramitsu.atlassian.net/secure/RapidBoard.jspa?rapidView=36&projectKey=BSM&modal=detail&selectedIssue=BSM-76


This PR contains cryptographical primitives for JSONs.

We have VC and DDO, each has "proof" field. 

Proof consists of 
- signature type
- created - time when json is signed
- creator - public key or URI to public key (DID + fragment)
- nonce - random string
- purpose - string, purpose of signing (optional)
- hexencoded signature value 

example:

For JSON: `{"a": 1}`

`Ed25519Sha3SignatureSuite::sign` will return the following JSON:

```
{
  "a": 1,
  "proof": {
    "type": "Ed25519Sha3Signature",
    "creator": "bogdan",
    "created": "<time>",
    "nonce": "91823916293",
    "signatureValue": "<hexsignature>"
  }
}
```

and `Ed25519Sha3SignatureSuite::verify` will return TRUE, if signature is valid, false otherwise.

Potentially we will have many algorithms (encryption, digital signature, hashing, etc). Each of them will be packed in **suites**. 

This PR contains one suite - `Ed25519Sha3SignatureSuite`.
Each suite consists of:

- Signer
- Verifier
- JSON Mapper
- Canonizer - this one the term from w3c for "stable serialization". I.e. canonized JSON is a byte representation of JSON, which is the same for all **equal** JSONs.

