### PR TITLE
Refactor

### DIFF
--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/ArrayTree.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/ArrayTree.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.common;
+package jp.co.soramitsu.sora.crypto.common;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/ArrayTreeFactory.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/ArrayTreeFactory.java
@@ -1,6 +1,6 @@
-package jp.co.soramitsu.sora.common;
+package jp.co.soramitsu.sora.crypto.common;
 
-import static jp.co.soramitsu.sora.common.Util.ceilToPowerOf2;
+import static jp.co.soramitsu.sora.crypto.common.Util.ceilToPowerOf2;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/HexdigestSaltGenerator.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/HexdigestSaltGenerator.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.common;
+package jp.co.soramitsu.sora.crypto.common;
 
 import java.util.Random;
 import javax.xml.bind.DatatypeConverter;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/InvalidNodeNumberException.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/InvalidNodeNumberException.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.common;
+package jp.co.soramitsu.sora.crypto.common;
 
 public class InvalidNodeNumberException extends RuntimeException {
 

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/SaltGenerator.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/SaltGenerator.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.common;
+package jp.co.soramitsu.sora.crypto.common;
 
 public interface SaltGenerator {
 

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/SecurityProvider.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/SecurityProvider.java
@@ -7,6 +7,9 @@ import java.security.NoSuchProviderException;
 import java.security.Security;
 import java.security.Signature;
 import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider;
+import jp.co.soramitsu.sora.crypto.type.DigestTypeEnum;
+import jp.co.soramitsu.sora.crypto.type.KeyTypeEnum;
+import jp.co.soramitsu.sora.crypto.type.SignatureTypeEnum;
 import org.spongycastle.jce.provider.BouncyCastleProvider;
 
 

--- a/src/main/java/jp/co/soramitsu/sora/crypto/common/Util.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/common/Util.java
@@ -1,14 +1,13 @@
-package jp.co.soramitsu.sora.common;
+package jp.co.soramitsu.sora.crypto.common;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.Signature;
 import java.security.SignatureException;
-import jp.co.soramitsu.sora.crypto.Hash;
-import jp.co.soramitsu.sora.crypto.common.Consts;
+import jp.co.soramitsu.sora.crypto.json.JSONCanonizer;
+import jp.co.soramitsu.sora.crypto.merkle.Hash;
 import jp.co.soramitsu.sora.crypto.proof.Options;
-import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
 import org.spongycastle.util.Arrays;
 
 public class Util {

--- a/src/main/java/jp/co/soramitsu/sora/crypto/json/BadJsonException.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/json/BadJsonException.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.json;
+package jp.co.soramitsu.sora.crypto.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 

--- a/src/main/java/jp/co/soramitsu/sora/crypto/json/FlattenException.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/json/FlattenException.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.json;
+package jp.co.soramitsu.sora.crypto.json;
 
 public class FlattenException extends RuntimeException {
 

--- a/src/main/java/jp/co/soramitsu/sora/crypto/json/Flattener.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/json/Flattener.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.json;
+package jp.co.soramitsu.sora.crypto.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/json/Hashifier.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/json/Hashifier.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.json;
+package jp.co.soramitsu.sora.crypto.json;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/json/JSONCanonizer.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/json/JSONCanonizer.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.crypto.service;
+package jp.co.soramitsu.sora.crypto.json;
 
 import java.io.IOException;
 

--- a/src/main/java/jp/co/soramitsu/sora/crypto/json/JSONCanonizerWithOneCoding.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/json/JSONCanonizerWithOneCoding.java
@@ -1,9 +1,8 @@
-package jp.co.soramitsu.sora.crypto.service.impl;
+package jp.co.soramitsu.sora.crypto.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import jp.co.soramitsu.jackson.OneCodeMapper;
-import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
 import lombok.NoArgsConstructor;
 
 

--- a/src/main/java/jp/co/soramitsu/sora/crypto/json/JSONSigner.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/json/JSONSigner.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.crypto.service;
+package jp.co.soramitsu.sora.crypto.json;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/json/JSONSignerImpl.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/json/JSONSignerImpl.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.crypto.service.impl;
+package jp.co.soramitsu.sora.crypto.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -6,12 +6,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.security.Signature;
 import java.security.SignatureException;
-import jp.co.soramitsu.sora.common.Util;
 import jp.co.soramitsu.sora.crypto.common.Consts;
+import jp.co.soramitsu.sora.crypto.common.Util;
 import jp.co.soramitsu.sora.crypto.proof.Options;
 import jp.co.soramitsu.sora.crypto.proof.Proof;
-import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
-import jp.co.soramitsu.sora.crypto.service.JSONSigner;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/json/JSONVerifier.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/json/JSONVerifier.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.crypto.service;
+package jp.co.soramitsu.sora.crypto.json;
 
 import java.io.IOException;
 import java.security.Signature;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/json/JSONVerifierImpl.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/json/JSONVerifierImpl.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.crypto.service.impl;
+package jp.co.soramitsu.sora.crypto.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -6,12 +6,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.security.Signature;
 import java.security.SignatureException;
-import jp.co.soramitsu.sora.common.Util;
 import jp.co.soramitsu.sora.crypto.common.Consts;
+import jp.co.soramitsu.sora.crypto.common.Util;
 import jp.co.soramitsu.sora.crypto.proof.Options;
 import jp.co.soramitsu.sora.crypto.proof.Proof;
-import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
-import jp.co.soramitsu.sora.crypto.service.JSONVerifier;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.experimental.FieldDefaults;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/json/NotJsonObjectException.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/json/NotJsonObjectException.java
@@ -1,11 +1,11 @@
-package jp.co.soramitsu.sora.json;
+package jp.co.soramitsu.sora.crypto.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class NotJsonObjectException extends RuntimeException {
 
   public NotJsonObjectException(JsonNode root) {
-    super("Not an object JSON: " + root.toString());
+    super("Not a JSON object :" + root.toString());
   }
 
 }

--- a/src/main/java/jp/co/soramitsu/sora/crypto/json/Saltifier.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/json/Saltifier.java
@@ -1,10 +1,10 @@
-package jp.co.soramitsu.sora.json;
+package jp.co.soramitsu.sora.crypto.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import jp.co.soramitsu.sora.common.SaltGenerator;
+import jp.co.soramitsu.sora.crypto.common.SaltGenerator;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.experimental.FieldDefaults;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/merkle/Hash.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/merkle/Hash.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.crypto;
+package jp.co.soramitsu.sora.crypto.merkle;
 
 import javax.xml.bind.DatatypeConverter;
 import lombok.Value;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/merkle/InvalidMerkleTreeException.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/merkle/InvalidMerkleTreeException.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.crypto;
+package jp.co.soramitsu.sora.crypto.merkle;
 
 public class InvalidMerkleTreeException extends RuntimeException {
 

--- a/src/main/java/jp/co/soramitsu/sora/crypto/merkle/MerkleNode.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/merkle/MerkleNode.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.crypto;
+package jp.co.soramitsu.sora.crypto.merkle;
 
 import lombok.Value;
 

--- a/src/main/java/jp/co/soramitsu/sora/crypto/merkle/MerkleTree.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/merkle/MerkleTree.java
@@ -1,12 +1,12 @@
-package jp.co.soramitsu.sora.crypto;
+package jp.co.soramitsu.sora.crypto.merkle;
 
-import static jp.co.soramitsu.sora.common.ArrayTree.getNeighborIndex;
-import static jp.co.soramitsu.sora.common.ArrayTree.getParentIndex;
+import static jp.co.soramitsu.sora.crypto.common.ArrayTree.getNeighborIndex;
+import static jp.co.soramitsu.sora.crypto.common.ArrayTree.getParentIndex;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
-import jp.co.soramitsu.sora.common.ArrayTree;
+import jp.co.soramitsu.sora.crypto.common.ArrayTree;
 import lombok.Value;
 
 @Value

--- a/src/main/java/jp/co/soramitsu/sora/crypto/merkle/MerkleTreeFactory.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/merkle/MerkleTreeFactory.java
@@ -1,15 +1,15 @@
-package jp.co.soramitsu.sora.crypto;
+package jp.co.soramitsu.sora.crypto.merkle;
 
 import static java.util.Objects.nonNull;
-import static jp.co.soramitsu.sora.common.Util.ceilToPowerOf2;
+import static jp.co.soramitsu.sora.crypto.common.Util.ceilToPowerOf2;
 
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.List;
-import jp.co.soramitsu.sora.common.ArrayTree;
-import jp.co.soramitsu.sora.common.ArrayTreeFactory;
-import jp.co.soramitsu.sora.common.InvalidNodeNumberException;
-import jp.co.soramitsu.sora.common.Util;
+import jp.co.soramitsu.sora.crypto.common.ArrayTree;
+import jp.co.soramitsu.sora.crypto.common.ArrayTreeFactory;
+import jp.co.soramitsu.sora.crypto.common.InvalidNodeNumberException;
+import jp.co.soramitsu.sora.crypto.common.Util;
 import lombok.NonNull;
 import lombok.val;
 

--- a/src/main/java/jp/co/soramitsu/sora/crypto/merkle/MerkleTreeProof.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/merkle/MerkleTreeProof.java
@@ -1,12 +1,12 @@
-package jp.co.soramitsu.sora.crypto;
+package jp.co.soramitsu.sora.crypto.merkle;
 
-import static jp.co.soramitsu.sora.common.ArrayTree.getParentIndex;
+import static jp.co.soramitsu.sora.crypto.common.ArrayTree.getParentIndex;
 
 import java.security.MessageDigest;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
-import jp.co.soramitsu.sora.common.Util;
+import jp.co.soramitsu.sora.crypto.common.Util;
 import lombok.NonNull;
 import lombok.Value;
 

--- a/src/main/java/jp/co/soramitsu/sora/crypto/merkle/RootHashMismatchException.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/merkle/RootHashMismatchException.java
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.sora.crypto;
+package jp.co.soramitsu.sora.crypto.merkle;
 
 import javax.xml.bind.DatatypeConverter;
 import lombok.Getter;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/proof/Options.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/proof/Options.java
@@ -1,7 +1,7 @@
 package jp.co.soramitsu.sora.crypto.proof;
 
 import javax.validation.constraints.NotBlank;
-import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum;
+import jp.co.soramitsu.sora.crypto.type.SignatureTypeEnum;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NonNull;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/proof/Proof.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/proof/Proof.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import javax.validation.constraints.NotBlank;
-import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum;
+import jp.co.soramitsu.sora.crypto.type.SignatureTypeEnum;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuite.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuite.java
@@ -9,14 +9,14 @@ import java.security.SignatureException;
 import jp.co.soramitsu.crypto.ed25519.EdDSAPrivateKey;
 import jp.co.soramitsu.crypto.ed25519.EdDSAPublicKey;
 import jp.co.soramitsu.sora.crypto.common.SecurityProvider;
-import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum;
+import jp.co.soramitsu.sora.crypto.json.JSONCanonizer;
+import jp.co.soramitsu.sora.crypto.json.JSONCanonizerWithOneCoding;
+import jp.co.soramitsu.sora.crypto.json.JSONSigner;
+import jp.co.soramitsu.sora.crypto.json.JSONSignerImpl;
+import jp.co.soramitsu.sora.crypto.json.JSONVerifier;
+import jp.co.soramitsu.sora.crypto.json.JSONVerifierImpl;
 import jp.co.soramitsu.sora.crypto.proof.Options;
-import jp.co.soramitsu.sora.crypto.service.JSONCanonizer;
-import jp.co.soramitsu.sora.crypto.service.JSONSigner;
-import jp.co.soramitsu.sora.crypto.service.JSONVerifier;
-import jp.co.soramitsu.sora.crypto.service.impl.JSONCanonizerWithOneCoding;
-import jp.co.soramitsu.sora.crypto.service.impl.JSONSignerImpl;
-import jp.co.soramitsu.sora.crypto.service.impl.JSONVerifierImpl;
+import jp.co.soramitsu.sora.crypto.type.SignatureTypeEnum;
 import lombok.SneakyThrows;
 
 

--- a/src/main/java/jp/co/soramitsu/sora/crypto/type/DigestTypeEnum.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/type/DigestTypeEnum.java
@@ -1,5 +1,6 @@
-package jp.co.soramitsu.sora.crypto.common;
+package jp.co.soramitsu.sora.crypto.type;
 
+import jp.co.soramitsu.sora.crypto.common.Consts;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/type/KeyTypeEnum.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/type/KeyTypeEnum.java
@@ -1,7 +1,8 @@
-package jp.co.soramitsu.sora.crypto.common;
+package jp.co.soramitsu.sora.crypto.type;
 
 import jp.co.soramitsu.crypto.ed25519.EdDSAKey;
 import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider;
+import jp.co.soramitsu.sora.crypto.common.Consts;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/jp/co/soramitsu/sora/crypto/type/SignatureTypeEnum.java
+++ b/src/main/java/jp/co/soramitsu/sora/crypto/type/SignatureTypeEnum.java
@@ -1,8 +1,9 @@
-package jp.co.soramitsu.sora.crypto.common;
+package jp.co.soramitsu.sora.crypto.type;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import jp.co.soramitsu.crypto.ed25519.EdDSAEngine;
 import jp.co.soramitsu.crypto.ed25519.EdDSASecurityProvider;
+import jp.co.soramitsu.sora.crypto.common.Consts;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/test/groovy/jp/co/soramitsu/sora/common/ArrayTreeTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/common/ArrayTreeTest.groovy
@@ -1,5 +1,8 @@
 package jp.co.soramitsu.sora.common
 
+import jp.co.soramitsu.sora.crypto.common.ArrayTree
+import jp.co.soramitsu.sora.crypto.common.ArrayTreeFactory
+import jp.co.soramitsu.sora.crypto.common.InvalidNodeNumberException
 import spock.lang.Specification
 
 

--- a/src/test/groovy/jp/co/soramitsu/sora/common/SaltGeneratorTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/common/SaltGeneratorTest.groovy
@@ -1,5 +1,6 @@
 package jp.co.soramitsu.sora.common
 
+import jp.co.soramitsu.sora.crypto.common.HexdigestSaltGenerator
 import spock.lang.Specification
 
 import javax.xml.bind.DatatypeConverter

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/MerkleTreeTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/MerkleTreeTest.groovy
@@ -3,6 +3,7 @@ package jp.co.soramitsu.sora.crypto
 import jp.co.soramitsu.sora.common.ArrayTree
 import jp.co.soramitsu.sora.common.ArrayTreeFactory
 import jp.co.soramitsu.sora.common.MockSumMessageDigest
+import jp.co.soramitsu.sora.crypto.merkle.*
 import spock.lang.Specification
 import spock.lang.Unroll
 

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/MerkleTreeTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/MerkleTreeTest.groovy
@@ -1,13 +1,14 @@
 package jp.co.soramitsu.sora.crypto
 
-import jp.co.soramitsu.sora.common.ArrayTree
-import jp.co.soramitsu.sora.common.ArrayTreeFactory
 import jp.co.soramitsu.sora.common.MockSumMessageDigest
+import jp.co.soramitsu.sora.crypto.common.ArrayTree
+import jp.co.soramitsu.sora.crypto.common.ArrayTreeFactory
 import jp.co.soramitsu.sora.crypto.merkle.*
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import static jp.co.soramitsu.sora.common.Util.ceilToPowerOf2
+import static jp.co.soramitsu.sora.crypto.common.Util.ceilToPowerOf2
+
 
 class MerkleTreeTest extends Specification {
 

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/service/impl/JSONCanonizerWithOneCodingTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/service/impl/JSONCanonizerWithOneCodingTest.groovy
@@ -1,6 +1,7 @@
 package jp.co.soramitsu.sora.crypto.service.impl
 
-import jp.co.soramitsu.sora.crypto.service.JSONCanonizer
+import jp.co.soramitsu.sora.crypto.json.JSONCanonizer
+import jp.co.soramitsu.sora.crypto.json.JSONCanonizerWithOneCoding
 import spock.lang.Specification
 
 

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImplTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/service/impl/JSONSignerImplTest.groovy
@@ -3,11 +3,12 @@ package jp.co.soramitsu.sora.crypto.service.impl
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
 import jp.co.soramitsu.sora.common.MockSignature
-import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum
+import jp.co.soramitsu.sora.crypto.json.JSONCanonizer
+import jp.co.soramitsu.sora.crypto.json.JSONSigner
+import jp.co.soramitsu.sora.crypto.json.JSONSignerImpl
 import jp.co.soramitsu.sora.crypto.proof.Options
 import jp.co.soramitsu.sora.crypto.proof.Proof
-import jp.co.soramitsu.sora.crypto.service.JSONCanonizer
-import jp.co.soramitsu.sora.crypto.service.JSONSigner
+import jp.co.soramitsu.sora.crypto.type.SignatureTypeEnum
 import spock.lang.Specification
 
 import java.security.PrivateKey

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImplTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/service/impl/JSONVerifierImplTest.groovy
@@ -3,16 +3,16 @@ package jp.co.soramitsu.sora.crypto.service.impl
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
 import jp.co.soramitsu.sora.common.MockSignature
-import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum
+import jp.co.soramitsu.sora.crypto.json.JSONCanonizer
+import jp.co.soramitsu.sora.crypto.json.JSONVerifier
+import jp.co.soramitsu.sora.crypto.json.JSONVerifierImpl
 import jp.co.soramitsu.sora.crypto.proof.Options
 import jp.co.soramitsu.sora.crypto.proof.Proof
-import jp.co.soramitsu.sora.crypto.service.JSONCanonizer
-import jp.co.soramitsu.sora.crypto.service.JSONVerifier
+import jp.co.soramitsu.sora.crypto.type.SignatureTypeEnum
 import spock.lang.Specification
 
 import java.security.PublicKey
 import java.security.Signature
-
 
 class JSONVerifierImplTest extends Specification {
 

--- a/src/test/groovy/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuiteTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/crypto/signature/suite/JSONEd25519Sha3SignatureSuiteTest.groovy
@@ -6,18 +6,14 @@ import jp.co.soramitsu.crypto.ed25519.EdDSAPrivateKey
 import jp.co.soramitsu.crypto.ed25519.EdDSAPublicKey
 import jp.co.soramitsu.sora.common.MockSignature
 import jp.co.soramitsu.sora.crypto.common.Consts
-import jp.co.soramitsu.sora.crypto.common.KeyTypeEnum
 import jp.co.soramitsu.sora.crypto.common.SecurityProvider
-import jp.co.soramitsu.sora.crypto.common.SignatureTypeEnum
+import jp.co.soramitsu.sora.crypto.json.JSONCanonizer
 import jp.co.soramitsu.sora.crypto.proof.Options
-import jp.co.soramitsu.sora.crypto.service.JSONCanonizer
+import jp.co.soramitsu.sora.crypto.type.KeyTypeEnum
+import jp.co.soramitsu.sora.crypto.type.SignatureTypeEnum
 import spock.lang.Specification
 
-import java.security.KeyPair
-import java.security.KeyPairGenerator
-import java.security.PrivateKey
-import java.security.PublicKey
-import java.security.Signature
+import java.security.*
 
 class JSONEd25519Sha3SignatureSuiteTest extends Specification {
 

--- a/src/test/groovy/jp/co/soramitsu/sora/json/FlattenerTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/json/FlattenerTest.groovy
@@ -2,6 +2,7 @@ package jp.co.soramitsu.sora.json
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import jp.co.soramitsu.sora.crypto.json.Flattener
 import spock.genesis.Gen
 import spock.genesis.transform.Iterations
 import spock.lang.Specification

--- a/src/test/groovy/jp/co/soramitsu/sora/json/HashifierTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/json/HashifierTest.groovy
@@ -1,6 +1,7 @@
 package jp.co.soramitsu.sora.json
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import jp.co.soramitsu.sora.crypto.json.Hashifier
 import spock.genesis.Gen
 import spock.lang.Specification
 

--- a/src/test/groovy/jp/co/soramitsu/sora/json/SaltifierTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/json/SaltifierTest.groovy
@@ -2,6 +2,7 @@ package jp.co.soramitsu.sora.json
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import jp.co.soramitsu.sora.common.SaltGenerator
+import jp.co.soramitsu.sora.crypto.json.Saltifier
 import spock.lang.Specification
 
 class SaltifierTest extends Specification {

--- a/src/test/groovy/jp/co/soramitsu/sora/json/SaltifierTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/json/SaltifierTest.groovy
@@ -1,7 +1,7 @@
 package jp.co.soramitsu.sora.json
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import jp.co.soramitsu.sora.common.SaltGenerator
+import jp.co.soramitsu.sora.crypto.common.SaltGenerator
 import jp.co.soramitsu.sora.crypto.json.Saltifier
 import spock.lang.Specification
 


### PR DESCRIPTION
- move sora.common to sora.crypto.common
- move enums to sora.crypto.type package
- move all classes related to merkle tree to sora.crypto.merkle package
- move sora.crpyto.service to sora.crypto.json
- move service.impl to sora.crypto.json
- run optimize import on all files

Signed-off-by: Bogdan Vaneev <warchantua@gmail.com>